### PR TITLE
zephyr: update module definition to enable usage as a module

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,4 @@
+name: roBa
 build:
   settings:
     board_root: .

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,4 +1,4 @@
 name: roBa
 build:
   settings:
-    board_root: .
+    board_root: config


### PR DESCRIPTION
This fixes up the zephyr module definition, thus allowing the shields to be imported and used in centralised user repositories (i.e., without having to fork this repository).
